### PR TITLE
Updated php-amqplib version for support php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "ext-sockets": "*",
-        "php-amqplib/php-amqplib": "^3.1.2",
+        "php-amqplib/php-amqplib": "^3.1.0",
         "yiisoft/factory": "^1.0",
         "yiisoft/friendly-exception": "^1.0",
         "yiisoft/yii-queue": "*"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "php-amqplib/php-amqplib": "^2.11|^3.0",
+        "ext-sockets": "*",
+        "php-amqplib/php-amqplib": "^3.1.2",
         "yiisoft/factory": "^1.0",
         "yiisoft/friendly-exception": "^1.0",
         "yiisoft/yii-queue": "*"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 


**php 8.0.16**

Fixed 

> Problem 1
>     - php-amqplib/php-amqplib[2.12.2, ..., 2.x-dev] require php >=5.6.3,<8.0 -> your php version (8.0.16) does not satisfy that requirement.
>     - php-amqplib/php-amqplib[dev-master, v2.11.0, ..., v2.12.1, 3.0.0-rc1, ..., v3.1.2] require ext-sockets * -> it is missing from your system. Install or enable PHP's sockets extension.
>     - php-amqplib/php-amqplib 3.0.x-dev is an alias of php-amqplib/php-amqplib dev-master and thus requires it to be installed too.
>     - Root composer.json requires php-amqplib/php-amqplib ^2.11|^3.0 -> satisfiable by php-amqplib/php-amqplib[v2.11.0, ..., 2.x-dev, 3.0.0-rc1, ..., v3.1.2].



