### PR TITLE
Rename package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Yii Queue AMQP Adapter Change Log
+# Queue AMQP Adapter Change Log
 
 ## 1.0.0 under development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Queue AMQP Adapter Change Log
+# Yii Queue AMQP Adapter Change Log
 
 ## 1.0.0 under development
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     <a href="https://github.com/yiisoft" target="_blank">
         <img src="https://github.com/yiisoft.png" height="100px">
     </a>
-    <h1 align="center">Queue AMQP Adapter</h1>
+    <h1 align="center">Yii Queue AMQP Adapter</h1>
     <br>
 </p>
 
-AMQP adapter based on [php-amqplib](https://github.com/php-amqplib/php-amqplib) package for [Queue](https://github.com/yiisoft/queue).
+AMQP adapter based on [php-amqplib](https://github.com/php-amqplib/php-amqplib) package for [Yii Queue](https://github.com/yiisoft/queue).
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/queue-amqp/v/stable.png)](https://packagist.org/packages/yiisoft/queue-amqp)
 [![Total Downloads](https://poser.pugx.org/yiisoft/queue-amqp/downloads.png)](https://packagist.org/packages/yiisoft/queue-amqp)
@@ -57,7 +57,7 @@ to the `require` section of your `composer.json` file.
 
 ## License
 
-The Queue AMQP Adapter is free software. It is released under the terms of the BSD License.
+The Yii Queue AMQP Adapter is free software. It is released under the terms of the BSD License.
 Please see [`LICENSE`](./LICENSE.md) for more information.
 
 Maintained by [Yii Software](https://www.yiiframework.com/).

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
     <a href="https://github.com/yiisoft" target="_blank">
         <img src="https://github.com/yiisoft.png" height="100px">
     </a>
-    <h1 align="center">Yii Queue AMQP Adapter</h1>
+    <h1 align="center">Queue AMQP Adapter</h1>
     <br>
 </p>
 
-AMQP adapter based on [php-amqplib](https://github.com/php-amqplib/php-amqplib) package for [Yii Queue](https://github.com/yiisoft/yii-queue).
+AMQP adapter based on [php-amqplib](https://github.com/php-amqplib/php-amqplib) package for [Queue](https://github.com/yiisoft/queue).
 
-[![Latest Stable Version](https://poser.pugx.org/yiisoft/yii-queue-amqp/v/stable.png)](https://packagist.org/packages/yiisoft/yii-queue-amqp)
-[![Total Downloads](https://poser.pugx.org/yiisoft/yii-queue-amqp/downloads.png)](https://packagist.org/packages/yiisoft/yii-queue-amqp)
-[![Build status](https://github.com/yiisoft/yii-queue-amqp/workflows/build/badge.svg)](https://github.com/yiisoft/yii-queue-amqp/actions?query=workflow%3Abuild)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiisoft/yii-queue-amqp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-queue-amqp/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/yiisoft/yii-queue-amqp/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-queue-amqp/?branch=master)
-[![static analysis](https://github.com/yiisoft/yii-queue-amqp/workflows/static%20analysis/badge.svg)](https://github.com/yiisoft/yii-queue-amqp/actions?query=workflow%3A%22static+analysis%22)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fyiisoft%2Fyii-queue-amqp%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/yiisoft/yii-queue-amqp/master)
-[![type-coverage](https://shepherd.dev/github/yiisoft/yii-queue-amqp/coverage.svg)](https://shepherd.dev/github/yiisoft/yii-queue-amqp)
+[![Latest Stable Version](https://poser.pugx.org/yiisoft/queue-amqp/v/stable.png)](https://packagist.org/packages/yiisoft/queue-amqp)
+[![Total Downloads](https://poser.pugx.org/yiisoft/queue-amqp/downloads.png)](https://packagist.org/packages/yiisoft/queue-amqp)
+[![Build status](https://github.com/yiisoft/queue-amqp/workflows/build/badge.svg)](https://github.com/yiisoft/queue-amqp/actions?query=workflow%3Abuild)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiisoft/queue-amqp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/queue-amqp/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/yiisoft/queue-amqp/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/queue-amqp/?branch=master)
+[![static analysis](https://github.com/yiisoft/queue-amqp/workflows/static%20analysis/badge.svg)](https://github.com/yiisoft/queue-amqp/actions?query=workflow%3A%22static+analysis%22)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fyiisoft%2Fqueue-amqp%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/yiisoft/queue-amqp/master)
+[![type-coverage](https://shepherd.dev/github/yiisoft/queue-amqp/coverage.svg)](https://shepherd.dev/github/yiisoft/queue-amqp)
 
 ## Requirements
 
@@ -28,13 +28,13 @@ The preferred way to install this extension is through [composer](http://getcomp
 Either run
 
 ```shell
-composer require yiisoft/yii-queue-amqp
+composer require yiisoft/queue-amqp
 ```
 
 or add
 
 ```
-"yiisoft/yii-queue-amqp": "dev-master"
+"yiisoft/queue-amqp": "dev-master"
 ```
 
 to the `require` section of your `composer.json` file.
@@ -57,7 +57,7 @@ to the `require` section of your `composer.json` file.
 
 ## License
 
-The Yii Queue AMQP Adapter is free software. It is released under the terms of the BSD License.
+The Queue AMQP Adapter is free software. It is released under the terms of the BSD License.
 Please see [`LICENSE`](./LICENSE.md) for more information.
 
 Maintained by [Yii Software](https://www.yiiframework.com/).

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yiisoft/queue-amqp",
     "type": "library",
-    "description": "Queue amqp adapter based on amqp-lib package",
+    "description": "Yii Queue AMQP adapter based on amqp-lib package",
     "keywords": [
         "yii",
         "queue",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php-amqplib/php-amqplib": "^3.1.0",
         "yiisoft/factory": "^1.0",
         "yiisoft/friendly-exception": "^1.0",
-        "yiisoft/yii-queue": "dev-rename-package"
+        "yiisoft/queue": "dev-master"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "yiisoft/yii-queue-amqp",
+    "name": "yiisoft/queue-amqp",
     "type": "library",
-    "description": "yii-queue amqp adapter based on amqp-lib package",
+    "description": "Queue amqp adapter based on amqp-lib package",
     "keywords": [
         "yii",
         "queue",
@@ -12,12 +12,12 @@
     "homepage": "https://www.yiiframework.com/",
     "license": "BSD-3-Clause",
     "support": {
-        "issues": "https://github.com/yiisoft/yii-queue-amqp/issues?state=open",
+        "issues": "https://github.com/yiisoft/queue-amqp/issues?state=open",
         "forum": "https://www.yiiframework.com/forum/",
         "wiki": "https://www.yiiframework.com/wiki/",
         "irc": "irc://irc.freenode.net/yii",
         "chat": "https://t.me/yii3en",
-        "source": "https://github.com/yiisoft/yii-queue-amqp"
+        "source": "https://github.com/yiisoft/queue-amqp"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -28,7 +28,7 @@
         "php-amqplib/php-amqplib": "^3.1.0",
         "yiisoft/factory": "^1.0",
         "yiisoft/friendly-exception": "^1.0",
-        "yiisoft/yii-queue": "dev-master"
+        "yiisoft/yii-queue": "dev-rename-package"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",
@@ -43,12 +43,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Yiisoft\\Yii\\Queue\\AMQP\\": "src"
+            "Yiisoft\\Queue\\AMQP\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Yiisoft\\Yii\\Queue\\AMQP\\Tests\\": "tests"
+            "Yiisoft\\Queue\\AMQP\\Tests\\": "tests"
         }
     },
     "extra": {

--- a/config/di.php
+++ b/config/di.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializerInterface;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\QueueProviderInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue;
-use Yiisoft\Yii\Queue\AMQP\Settings\QueueSettingsInterface;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\MessageSerializerInterface;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\QueueProviderInterface;
+use Yiisoft\Queue\AMQP\Settings\Queue;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 
 return [
     MessageSerializerInterface::class => MessageSerializer::class,

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,3 +1,3 @@
-# Yii Queue AMQP Adapter documentation
+# Queue AMQP Adapter documentation
 
 - [Internals](internals.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,3 +1,3 @@
-# Queue AMQP Adapter documentation
+# Yii Queue AMQP Adapter documentation
 
 - [Internals](internals.md)

--- a/docs/en/internals.md
+++ b/docs/en/internals.md
@@ -41,7 +41,7 @@ You can use any of the supported PHP versions with service names `php80`, `php81
 To debug code with xDebug and to use volumes inside the built containers, you can use
 `test/docker-compose.development.yml`. To do so you should either run
 `docker compose -f docker-compose.yml -f docker-compose.development.yml run --rm php<version> vendor/bin/phpunit`
-or copy [tests/.env.example](tests/.env.example) into `tests/.env` and run tests as usual.
+or copy [tests/.env.example](../../tests/.env.example) into `tests/.env` and run tests as usual.
 
 Also, if you are using Docker, then you have access to a set of prepared commands in the Makefile
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,14 +13,8 @@
 >
     <coverage>
         <include>
-            <directory>./</directory>
+            <directory>src</directory>
         </include>
-        <exclude>
-            <directory>./tests</directory>
-            <directory>./vendor</directory>
-            <directory>./config</directory>
-            <file>./rector.php</file>
-        </exclude>
     </coverage>
     <php>
         <ini name="error_reporting" value="-1"/>

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
 use PhpAmqpLib\Message\AMQPMessage;
 use Throwable;
-use Yiisoft\Yii\Queue\Adapter\AdapterInterface;
-use Yiisoft\Yii\Queue\AMQP\Exception\NotImplementedException;
-use Yiisoft\Yii\Queue\Cli\LoopInterface;
-use Yiisoft\Yii\Queue\Enum\JobStatus;
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Adapter\AdapterInterface;
+use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
+use Yiisoft\Queue\Cli\LoopInterface;
+use Yiisoft\Queue\Enum\JobStatus;
+use Yiisoft\Queue\Message\MessageInterface;
 
 final class Adapter implements AdapterInterface
 {

--- a/src/Exception/ExchangeDeclaredException.php
+++ b/src/Exception/ExchangeDeclaredException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Exception;
+namespace Yiisoft\Queue\AMQP\Exception;
 
 use InvalidArgumentException;
 use Yiisoft\FriendlyException\FriendlyExceptionInterface;

--- a/src/Exception/NoKeyInPayloadException.php
+++ b/src/Exception/NoKeyInPayloadException.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Exception;
+namespace Yiisoft\Queue\AMQP\Exception;
 
 use InvalidArgumentException;
 use Throwable;
 use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+use Yiisoft\Queue\AMQP\MessageSerializerInterface;
 
 class NoKeyInPayloadException extends InvalidArgumentException implements FriendlyExceptionInterface
 {
@@ -40,9 +41,14 @@ class NoKeyInPayloadException extends InvalidArgumentException implements Friend
      */
     public function getSolution(): ?string
     {
-        return 'We have successfully unserialized a message, but there was no expected key "' . $this->expectedKey . '".
-        There are the following keys in the message: ' . implode(', ', array_keys($this->payload)) . '.
-        You might want to change message\'s structure, or make your own implementation of \\Yiisoft\\Yii\\Queue\\AMQP\\MessageSerializerInterface,
-        which won\'t rely on this key in the message.';
+        return sprintf(
+            "We have successfully unserialized a message, but there was no expected key \"%s\".
+        There are the following keys in the message: %s.
+        You might want to change message's structure, or make your own implementation of %s,
+        which won't rely on this key in the message.",
+            $this->expectedKey,
+            implode(', ', array_keys($this->payload)),
+            MessageSerializerInterface::class
+        );
     }
 }

--- a/src/Exception/NotImplementedException.php
+++ b/src/Exception/NotImplementedException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Exception;
+namespace Yiisoft\Queue\AMQP\Exception;
 
 use RuntimeException;
 

--- a/src/ExistingMessagesConsumer.php
+++ b/src/ExistingMessagesConsumer.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Throwable;
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Message\MessageInterface;
 
 /**
  * @internal

--- a/src/MessageSerializer.php
+++ b/src/MessageSerializer.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
 use InvalidArgumentException;
 use JsonException;
-use Yiisoft\Yii\Queue\AMQP\Exception\NoKeyInPayloadException;
-use Yiisoft\Yii\Queue\Message\Message;
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\AMQP\Exception\NoKeyInPayloadException;
+use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\MessageInterface;
 
 class MessageSerializer implements MessageSerializerInterface
 {

--- a/src/MessageSerializerInterface.php
+++ b/src/MessageSerializerInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Message\MessageInterface;
 
 interface MessageSerializerInterface
 {

--- a/src/Middleware/DelayMiddleware.php
+++ b/src/Middleware/DelayMiddleware.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Middleware;
+namespace Yiisoft\Queue\AMQP\Middleware;
 
 use InvalidArgumentException;
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\QueueProviderInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\ExchangeSettingsInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\QueueSettingsInterface;
-use Yiisoft\Yii\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
-use Yiisoft\Yii\Queue\Middleware\Push\MessageHandlerPushInterface;
-use Yiisoft\Yii\Queue\Middleware\Push\PushRequest;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\QueueProviderInterface;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
+use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
+use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;
+use Yiisoft\Queue\Middleware\Push\PushRequest;
 
 final class DelayMiddleware implements DelayMiddlewareInterface
 {

--- a/src/QueueProvider.php
+++ b/src/QueueProvider.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
-use Yiisoft\Yii\Queue\AMQP\Exception\ExchangeDeclaredException;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange;
-use Yiisoft\Yii\Queue\AMQP\Settings\ExchangeSettingsInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\QueueSettingsInterface;
+use Yiisoft\Queue\AMQP\Exception\ExchangeDeclaredException;
+use Yiisoft\Queue\AMQP\Settings\Exchange;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 
 final class QueueProvider implements QueueProviderInterface
 {

--- a/src/QueueProviderInterface.php
+++ b/src/QueueProviderInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP;
+namespace Yiisoft\Queue\AMQP;
 
 use PhpAmqpLib\Channel\AMQPChannel;
-use Yiisoft\Yii\Queue\AMQP\Settings\ExchangeSettingsInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\QueueSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 
 interface QueueProviderInterface
 {

--- a/src/Settings/Exchange.php
+++ b/src/Settings/Exchange.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Settings;
+namespace Yiisoft\Queue\AMQP\Settings;
 
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Wire\AMQPTable;

--- a/src/Settings/ExchangeSettingsInterface.php
+++ b/src/Settings/ExchangeSettingsInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Settings;
+namespace Yiisoft\Queue\AMQP\Settings;
 
 use PhpAmqpLib\Wire\AMQPTable;
 
@@ -29,7 +29,7 @@ interface ExchangeSettingsInterface
     /**
      * Positional arguments to be used with {@see \PhpAmqpLib\Channel\AMQPChannel::exchange_declare()}
      *
-     * @see \Yiisoft\Yii\Queue\AMQP\QueueProvider::getChannel()
+     * @see \Yiisoft\Queue\AMQP\QueueProvider::getChannel()
      *
      * @return (AMQPTable|array|bool|int|string|null)[]
      *

--- a/src/Settings/Queue.php
+++ b/src/Settings/Queue.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Settings;
+namespace Yiisoft\Queue\AMQP\Settings;
 
 use PhpAmqpLib\Wire\AMQPTable;
-use Yiisoft\Yii\Queue\QueueFactoryInterface;
+use Yiisoft\Queue\QueueFactoryInterface;
 
 final class Queue implements QueueSettingsInterface
 {

--- a/src/Settings/QueueSettingsInterface.php
+++ b/src/Settings/QueueSettingsInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Settings;
+namespace Yiisoft\Queue\AMQP\Settings;
 
 use PhpAmqpLib\Wire\AMQPTable;
 
@@ -27,7 +27,7 @@ interface QueueSettingsInterface
     /**
      * Returns positional arguments to be used with {@see \PhpAmqpLib\Channel\AMQPChannel::queue_declare()}
      *
-     * @see \Yiisoft\Yii\Queue\AMQP\QueueProvider::getChannel()
+     * @see \Yiisoft\Queue\AMQP\QueueProvider::getChannel()
      *
      * @return (AMQPTable|array|bool|int|string|null)[]
      *

--- a/tests/Integration/DelayMiddlewareTest.php
+++ b/tests/Integration/DelayMiddlewareTest.php
@@ -2,27 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Integration;
+namespace Yiisoft\Queue\AMQP\Tests\Integration;
 
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use Yiisoft\Yii\Queue\Adapter\AdapterInterface;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\Middleware\DelayMiddleware;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FakeAdapter;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\Cli\LoopInterface;
-use Yiisoft\Yii\Queue\Cli\SignalLoop;
-use Yiisoft\Yii\Queue\Message\Message;
-use Yiisoft\Yii\Queue\Middleware\CallableFactory;
-use Yiisoft\Yii\Queue\Middleware\Push\MiddlewareFactoryPush;
-use Yiisoft\Yii\Queue\Middleware\Push\PushMiddlewareDispatcher;
-use Yiisoft\Yii\Queue\Queue;
-use Yiisoft\Yii\Queue\Worker\WorkerInterface;
+use Yiisoft\Queue\Adapter\AdapterInterface;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\Middleware\DelayMiddleware;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Tests\Support\FakeAdapter;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\AMQP\Tests\Support\SimpleMessageHandler;
+use Yiisoft\Queue\Cli\LoopInterface;
+use Yiisoft\Queue\Cli\SignalLoop;
+use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Middleware\CallableFactory;
+use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
+use Yiisoft\Queue\Queue;
+use Yiisoft\Queue\Worker\WorkerInterface;
+use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class DelayMiddlewareTest extends TestCase
 {
@@ -94,7 +96,9 @@ final class DelayMiddlewareTest extends TestCase
             $this->createMock(LoggerInterface::class),
             new PushMiddlewareDispatcher(
                 new MiddlewareFactoryPush(
-                    $this->createMock(ContainerInterface::class),
+                    new SimpleContainer([
+                        'simple' => new SimpleMessageHandler(new FileHelper()),
+                    ]),
                     new CallableFactory($this->createMock(ContainerInterface::class)),
                 ),
             ),

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Integration;
+namespace Yiisoft\Queue\AMQP\Tests\Integration;
 
 use Symfony\Component\Process\Process;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\MainTestCase;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\AMQP\Tests\Support\MainTestCase;
 
 abstract class TestCase extends MainTestCase
 {

--- a/tests/Support/ExtendedSimpleMessageHandler.php
+++ b/tests/Support/ExtendedSimpleMessageHandler.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Support;
+namespace Yiisoft\Queue\AMQP\Tests\Support;
 
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Message\MessageInterface;
 
 /**
  * Accepts any values from the queue and writes to the file

--- a/tests/Support/FakeAdapter.php
+++ b/tests/Support/FakeAdapter.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Support;
+namespace Yiisoft\Queue\AMQP\Tests\Support;
 
-use Yiisoft\Yii\Queue\Adapter\AdapterInterface;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializerInterface;
-use Yiisoft\Yii\Queue\AMQP\QueueProviderInterface;
-use Yiisoft\Yii\Queue\Cli\LoopInterface;
-use Yiisoft\Yii\Queue\Enum\JobStatus;
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Adapter\AdapterInterface;
+use Yiisoft\Queue\AMQP\MessageSerializerInterface;
+use Yiisoft\Queue\AMQP\QueueProviderInterface;
+use Yiisoft\Queue\Cli\LoopInterface;
+use Yiisoft\Queue\Enum\JobStatus;
+use Yiisoft\Queue\Message\MessageInterface;
 
 final class FakeAdapter implements AdapterInterface
 {

--- a/tests/Support/FileHelper.php
+++ b/tests/Support/FileHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Support;
+namespace Yiisoft\Queue\AMQP\Tests\Support;
 
 use RuntimeException;
 

--- a/tests/Support/MainTestCase.php
+++ b/tests/Support/MainTestCase.php
@@ -2,22 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Support;
+namespace Yiisoft\Queue\AMQP\Tests\Support;
 
-use Exception;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
-use PHPUnit\Framework\TestCase as PhpUnitTestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class MainTestCase extends PhpUnitTestCase
+abstract class MainTestCase extends TestCase
 {
     public ?string $queueName = 'yii-queue';
     public ?string $exchangeName = 'yii-queue';
 
-    /**
-     * @throws Exception
-     *
-     * @return AMQPStreamConnection
-     */
     protected function createConnection(): AMQPStreamConnection
     {
         return new AMQPStreamConnection(

--- a/tests/Support/SimpleMessageHandler.php
+++ b/tests/Support/SimpleMessageHandler.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Support;
+namespace Yiisoft\Queue\AMQP\Tests\Support;
 
-use Yiisoft\Yii\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Message\MessageInterface;
 
 final class SimpleMessageHandler
 {

--- a/tests/Unit/DelayMiddlewareTest.php
+++ b/tests/Unit/DelayMiddlewareTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
-use Yiisoft\Yii\Queue\AMQP\Middleware\DelayMiddleware;
+use Yiisoft\Queue\AMQP\Middleware\DelayMiddleware;
 
 final class DelayMiddlewareTest extends UnitTestCase
 {

--- a/tests/Unit/ExchangeSettingsTest.php
+++ b/tests/Unit/ExchangeSettingsTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Wire\AMQPTable;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 
 final class ExchangeSettingsTest extends UnitTestCase
 {

--- a/tests/Unit/FriendlyExceptionTest.php
+++ b/tests/Unit/FriendlyExceptionTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
-use Yiisoft\Yii\Queue\AMQP\Exception\ExchangeDeclaredException;
-use Yiisoft\Yii\Queue\AMQP\Exception\NoKeyInPayloadException;
+use Yiisoft\Queue\AMQP\Exception\ExchangeDeclaredException;
+use Yiisoft\Queue\AMQP\Exception\NoKeyInPayloadException;
 
 final class FriendlyExceptionTest extends UnitTestCase
 {

--- a/tests/Unit/MessageSerializerTest.php
+++ b/tests/Unit/MessageSerializerTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Exception;
 use InvalidArgumentException;
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\Exception\NoKeyInPayloadException;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\Exception\NoKeyInPayloadException;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 
 /**
  * Testing message serialization options

--- a/tests/Unit/QueueFactoryTest.php
+++ b/tests/Unit/QueueFactoryTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Yiisoft\Injector\Injector;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\Message\Message;
-use Yiisoft\Yii\Queue\Middleware\CallableFactory;
-use Yiisoft\Yii\Queue\QueueFactory;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Middleware\CallableFactory;
+use Yiisoft\Queue\QueueFactory;
 
 class QueueFactoryTest extends UnitTestCase
 {

--- a/tests/Unit/QueueProviderTest.php
+++ b/tests/Unit/QueueProviderTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\Exception\ExchangeDeclaredException;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\ExchangeSettingsInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\QueueSettingsInterface;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\Exception\ExchangeDeclaredException;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\Message\Message;
 
 final class QueueProviderTest extends UnitTestCase
 {

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Wire\AMQPTable;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Yii\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\Message\Message;
 
 final class QueueSettingsTest extends UnitTestCase
 {

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Queue\AMQP\Tests\Unit;
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Exception;
-use Yiisoft\Yii\Queue\Adapter\AdapterInterface;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\Exception\NotImplementedException;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializerInterface;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\QueueProviderInterface;
-use Yiisoft\Yii\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\Cli\LoopInterface;
-use Yiisoft\Yii\Queue\Exception\JobFailureException;
-use Yiisoft\Yii\Queue\Message\Message;
-use Yiisoft\Yii\Queue\Queue;
+use Yiisoft\Queue\Adapter\AdapterInterface;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\MessageSerializerInterface;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\QueueProviderInterface;
+use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\Cli\LoopInterface;
+use Yiisoft\Queue\Exception\JobFailureException;
+use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Queue;
 
 final class QueueTest extends UnitTestCase
 {

--- a/tests/docker/php/Dockerfile
+++ b/tests/docker/php/Dockerfile
@@ -18,7 +18,10 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS \
     && pecl clear-cache \
     && apk del .build-dependencies
 
-ADD . /app
+COPY composer.* /app/
 WORKDIR /app
 RUN composer install --prefer-dist --no-interaction
+
+ADD . /app
+
 CMD ["sleep", "infinity"]

--- a/tests/yii
+++ b/tests/yii
@@ -6,24 +6,24 @@ use Psr\Log\NullLogger;
 use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Yii\Console\Application;
-use Yiisoft\Yii\Queue\AMQP\Adapter;
-use Yiisoft\Yii\Queue\AMQP\MessageSerializer;
-use Yiisoft\Yii\Queue\AMQP\QueueProvider;
-use Yiisoft\Yii\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\FileHelper;
-use Yiisoft\Yii\Queue\AMQP\Tests\Support\SimpleMessageHandler;
-use Yiisoft\Yii\Queue\Cli\SignalLoop;
-use Yiisoft\Yii\Queue\Command\ListenCommand;
-use Yiisoft\Yii\Queue\Command\RunCommand;
-use Yiisoft\Yii\Queue\Middleware\CallableFactory;
-use Yiisoft\Yii\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
-use Yiisoft\Yii\Queue\Middleware\Consume\MiddlewareFactoryConsume;
-use Yiisoft\Yii\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
-use Yiisoft\Yii\Queue\Middleware\FailureHandling\MiddlewareFactoryFailure;
-use Yiisoft\Yii\Queue\Middleware\Push\MiddlewareFactoryPush;
-use Yiisoft\Yii\Queue\Middleware\Push\PushMiddlewareDispatcher;
-use Yiisoft\Yii\Queue\Queue;
-use Yiisoft\Yii\Queue\QueueFactory;
+use Yiisoft\Queue\AMQP\Adapter;
+use Yiisoft\Queue\AMQP\MessageSerializer;
+use Yiisoft\Queue\AMQP\QueueProvider;
+use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
+use Yiisoft\Queue\AMQP\Tests\Support\SimpleMessageHandler;
+use Yiisoft\Queue\Cli\SignalLoop;
+use Yiisoft\Queue\Command\ListenCommand;
+use Yiisoft\Queue\Command\RunCommand;
+use Yiisoft\Queue\Middleware\CallableFactory;
+use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
+use Yiisoft\Queue\Middleware\Consume\MiddlewareFactoryConsume;
+use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
+use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFactoryFailure;
+use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
+use Yiisoft\Queue\Queue;
+use Yiisoft\Queue\QueueFactory;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -31,7 +31,7 @@ $logger = new NullLogger();
 $container = new SimpleContainer([]);
 $injector = new Injector($container);
 $callableFactory = new CallableFactory($container);
-$worker = new \Yiisoft\Yii\Queue\Worker\Worker(
+$worker = new \Yiisoft\Queue\Worker\Worker(
     [
         'simple' => new SimpleMessageHandler(new FileHelper()),
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Related PR  | https://github.com/yiisoft/yii-queue/pull/184


The failed test still fail in master, I'll try to fix it separate

TODO:
- [x] Replace `yii-queue` in `composer.json` after renaming the `yii-queue` package and before merge current PR